### PR TITLE
feat: Use the new OIDC provider

### DIFF
--- a/README-Developing.md
+++ b/README-Developing.md
@@ -38,7 +38,7 @@ he NodeJS app's login button calls /login. This NodeJS route is defined in app.j
 	
 	Calls to Verify: 
 	
-	* /oidc/endpoint/default/authorize to handle the OIDC authentication flow
+	* /oauth2/authorize to handle the OIDC authentication flow
 	* /idaas/mtfim/sps/idaas/login to authentication the user
 	* /authsvc/mtfim/sps/authsvc to post the username & password for authentication
 	* /idaas/mtfim/sps/idaas/login/google for Google login
@@ -66,7 +66,7 @@ A logout consist of a number of actions:
 	
 	Calls to Verify: 
 	
-	* /oidc/endpoint/default/revoke to revoke tokens
+	* /oauth2/revoke to revoke tokens
 	* /idaas/mtfim/sps/idaas/logout to logout the user's session.
 
 	Theme files:
@@ -130,7 +130,7 @@ index.js gather the data, while the view  in **views/insurance/profile.hbs** ren
 		
 	Calls to Verify: 
 	
-	* /oidc/endpoint/default/userinfo to get the user's id and other OIDC claims
+	* /oauth2/userinfo to get the user's id and other OIDC claims
 	* /v2.0/Me API to get the full user profile 
 	* /v1.0/attributes API to get the user's custom attributes such as 'car'
 	* /dpcm/v1.0/privacy/data-usage-approval provides the data usage approval to retrieve if the user has accepted the terms, and to get the opt-in/opt-out status of the 2 'purposes' 

--- a/app.js
+++ b/app.js
@@ -56,7 +56,8 @@ var consent = require('./routes/consent');
 
 let oidcIssuer = process.env.OIDC_ISSUER;
 if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-  oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+  // for backward compatibility
+  oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
 }
 
 try {
@@ -114,7 +115,11 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(session({
   secret: 'secret sause',
   resave: false,
-  saveUninitialized: true
+  saveUninitialized: true,
+  cookie: {
+    secure: 'auto',
+    httpOnly: true
+  }
 }))
 
 // Initialize Passport

--- a/ci-theme/manage-theme.js
+++ b/ci-theme/manage-theme.js
@@ -44,23 +44,28 @@ async function getAccessToken() {
   // get token to talk with Verify
   // returns the body of the POST call as an object
 
-    var data = {
-      grant_type: 'client_credentials',
-      client_id: process.env.API_CLIENT_ID,
-      client_secret: process.env.API_SECRET,
-    };
+  let oidcIssuer = process.env.OIDC_ISSUER;
+  if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+  }
 
-    var options = {
-      method: 'POST',
-      url: process.env.OIDC_CI_BASE_URI + '/v1.0/endpoint/default/token',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      data: qs.stringify(data)
-    };
+  var data = {
+    grant_type: 'client_credentials',
+    client_id: process.env.API_CLIENT_ID,
+    client_secret: process.env.API_SECRET,
+  };
 
-    var response = await axios(options);
-    return response.data;
+  var options = {
+    method: 'POST',
+    url: oidcIssuer + '/token',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    data: qs.stringify(data)
+  };
+
+  var response = await axios(options);
+  return response.data;
 }
 
 async function getThemesData(accessToken) {

--- a/ci-theme/manage-theme.js
+++ b/ci-theme/manage-theme.js
@@ -46,7 +46,7 @@ async function getAccessToken() {
 
   let oidcIssuer = process.env.OIDC_ISSUER;
   if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
   }
 
   var data = {

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -1,5 +1,6 @@
 # Your tenant URL.  You must set this.
 OIDC_CI_BASE_URI=https://xxxxxxxxxx.verify.ibm.com
+OIDC_ISSUER=https://xxxxxxxxxx.verify.ibm.com/oauth2
 
 # API Client for client_credentials flow
 # Give full permissions for auto-setup

--- a/functions.js
+++ b/functions.js
@@ -21,10 +21,14 @@ function random_id() {
 
 function oidcIdToken(req, callback) {
   console.log(req.session.accessToken);
+  let oidcIssuer = process.env.OIDC_ISSUER;
+  if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+  }
 
   options = {
     method: 'GET',
-    url: process.env.OIDC_CI_BASE_URI + '/oidc/endpoint/default/userinfo',
+    url: oidcIssuer + '/userinfo',
     headers: {'Authorization': 'Bearer ' + req.session.accessToken}
   }
 
@@ -40,9 +44,14 @@ function oidcIdToken(req, callback) {
 }
 
 function authorize(clientID, clientSecret, callback) {
+  let oidcIssuer = process.env.OIDC_ISSUER;
+  if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+  }
+
   var options = {
     method: 'POST',
-    url: process.env.OIDC_CI_BASE_URI + '/v1.0/endpoint/default/token',
+    url: oidcIssuer + '/token',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
     },
@@ -738,10 +747,14 @@ async function createApplication(appName, redirectUrl, accessToken) {
     }
 
     console.log("App creation information:", data)
+    let oidcIssuer = process.env.OIDC_ISSUER;
+    if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+      oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+    }
 
     var options = {
       'method': 'post',
-      'url': process.env.OIDC_CI_BASE_URI + '/oidc/endpoint/default/client_registration',
+      'url': oidcIssuer + '/client_registration',
       'headers': {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${accessToken}`

--- a/functions.js
+++ b/functions.js
@@ -23,7 +23,7 @@ function oidcIdToken(req, callback) {
   console.log(req.session.accessToken);
   let oidcIssuer = process.env.OIDC_ISSUER;
   if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
   }
 
   options = {
@@ -46,7 +46,7 @@ function oidcIdToken(req, callback) {
 function authorize(clientID, clientSecret, callback) {
   let oidcIssuer = process.env.OIDC_ISSUER;
   if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
   }
 
   var options = {
@@ -749,7 +749,7 @@ async function createApplication(appName, redirectUrl, accessToken) {
     console.log("App creation information:", data)
     let oidcIssuer = process.env.OIDC_ISSUER;
     if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-      oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+      oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
     }
 
     var options = {

--- a/routes/index.js
+++ b/routes/index.js
@@ -63,9 +63,14 @@ router.get('/app/profile', function(req, res, next) {
         }
       }
 
+      let oidcIssuer = process.env.OIDC_ISSUER;
+      if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+        oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+      }
+
       var options = {
         method: 'GET',
-        url: process.env.OIDC_CI_BASE_URI + '/oidc/endpoint/default/userinfo',
+        url: oidcIssuer + '/userinfo',
         headers: {
           'Authorization': `Bearer ${userAccessToken}`
         }

--- a/routes/index.js
+++ b/routes/index.js
@@ -65,7 +65,7 @@ router.get('/app/profile', function(req, res, next) {
 
       let oidcIssuer = process.env.OIDC_ISSUER;
       if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-        oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+        oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
       }
 
       var options = {

--- a/routes/open-account.js
+++ b/routes/open-account.js
@@ -165,7 +165,7 @@ router.post('/car', function(req, res, next) {
                 console.log("Create user:", req.session.userEmail)
                 pbody = response.data;
                 console.log("Response code:", response.statusCode);
-                console.log("Create response:", JSON.stringify(pbody));
+                console.log("Create response:", JSON.stringify(body));
                 if(response.status == 201){
                   //success
                   res.render('insurance/open-account-car-success', {

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -11,7 +11,12 @@ router.get('/', async function(req, res, next) {
     }
   }
 
-  var response = await axios.get(process.env.OIDC_CI_BASE_URI+'/oidc/endpoint/default/userinfo', options);
+  let oidcIssuer = process.env.OIDC_ISSUER;
+  if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+  }
+
+  var response = await axios.get(oidcIssuer + '/userinfo', options);
   console.log('profile.js: ---- User ID token ----');
   var userinfo = response.data;
   var userinfo_string = JSON.stringify(userinfo, null, 2);

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -13,7 +13,7 @@ router.get('/', async function(req, res, next) {
 
   let oidcIssuer = process.env.OIDC_ISSUER;
   if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+    oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
   }
 
   var response = await axios.get(oidcIssuer + '/userinfo', options);

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -374,7 +374,7 @@ router.post('/', async function(req, res, next) {
 
       let oidcIssuer = process.env.OIDC_ISSUER;
       if (!process.env.OIDC_ISSUER || process.env.OIDC_ISSUER == "") {
-        oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oauth2";
+        oidcIssuer = process.env.OIDC_CI_BASE_URI + "/oidc/endpoint/default";
       }
 
       passport.use(new OpenIDStrategy({

--- a/views/insurance/open-account.hbs
+++ b/views/insurance/open-account.hbs
@@ -14,7 +14,7 @@
 			<form action="{{action}}" method="post">
 				<div class="input-list clear">
 					{{#unless loggedIn}}
-					<h3>Create an account an existing provider</h3>
+					<h3>Create an account using an existing provider</h3>
 					<div class="tx--social" style="margin:auto;max-width:600px">
 						<a href="/login-google" class="social-button" id="google-connect"> <span>Google</span></a>
 						<a href="/login-linkedin" class="social-button" id="linkedin-connect"> <span>LinkedIn</span></a>


### PR DESCRIPTION
Verify offers a more powerful OpenID Connect app connector that uses a new OIDC Provider implementation.

This update provides the following:

- Defaults to the `/oauth2` OIDC Provider, as opposed to `/oidc/endpoint/default`
- Allows the old OIDC Provider to be used by setting the value in `.env` for the "OIDC_ISSUER" variable
