### PR TITLE
fix: Upgraded dependencies break session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ web_modules/
 .env
 .env.test
 env.*
+.env.*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "debug": "DEBUG=express-session node ./bin/www"
   },
   "dependencies": {
     "axios": "^0.24.0",


### PR DESCRIPTION
New passport versions re-generate the session object on login. Unfortunately, the callback where the logged in status and the access token etc. is stored runs before the session cycling activity. This PR uses a workaround to merge the previous session with the newly created one.